### PR TITLE
Fixed Null Pointer exception on AST compilation

### DIFF
--- a/src/main/java/ghaffarian/progex/java/JavaASTBuilder.java
+++ b/src/main/java/ghaffarian/progex/java/JavaASTBuilder.java
@@ -1392,7 +1392,12 @@ public class JavaASTBuilder {
         @Override
         public String visitExpressionList(JavaParser.ExpressionListContext ctx) {
             // expressionList :  expression (',' expression)*
-            StringBuilder normalized = new StringBuilder(visit(ctx.expression(0)));
+	    String visitStr = visit(ctx.expression(0));
+            if(visitStr == null){
+                System.err.println("visit is "+ visitStr);
+                visitStr = "";
+            }
+            StringBuilder normalized = new StringBuilder(visitStr);
             for (int i = 1; i < ctx.expression().size(); ++i)
                 normalized.append(", ").append(visit(ctx.expression(i)));
             return normalized.toString();


### PR DESCRIPTION
Fixes #17 
There was an unsafe assignment @ ex line 1935 where the result of the call to visit method was directly passed to the string builder without checking for it's possibility to be null. The fix is as easy as it can be, it reports the null value and set it as an empty string,  the reson behind it's null value should be looked into it. 
But as far as programwise now it works and gets to the end of the analysis even of big projects like the apache ones.

Another viable fix is to try-catch the error and act consequently.